### PR TITLE
test: Track static separately

### DIFF
--- a/benches/access.rs
+++ b/benches/access.rs
@@ -15,11 +15,6 @@ fn bench_access(c: &mut Criterion) {
     for fixture in fixture::SAMPLES {
         let len = fixture.len();
         group.throughput(Throughput::Bytes(len as u64));
-        group.bench_with_input(BenchmarkId::new("&'static str", len), &len, |b, _| {
-            let uut = *fixture;
-            let uut = criterion::black_box(uut);
-            b.iter(|| uut.is_empty())
-        });
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let uut = String::from(*fixture);
             let uut = criterion::black_box(uut);
@@ -35,15 +30,6 @@ fn bench_access(c: &mut Criterion) {
             let uut = criterion::black_box(uut);
             b.iter(|| uut.is_empty())
         });
-        group.bench_with_input(
-            BenchmarkId::new("StringCow::Borrowed", len),
-            &len,
-            |b, _| {
-                let uut = StringCow::Borrowed(*fixture);
-                let uut = criterion::black_box(uut);
-                b.iter(|| uut.is_empty())
-            },
-        );
         group.bench_with_input(BenchmarkId::new("StringCow::Owned", len), &len, |b, _| {
             let uut = StringCow::Owned(String::from(*fixture));
             let uut = criterion::black_box(uut);
@@ -55,28 +41,10 @@ fn bench_access(c: &mut Criterion) {
             b.iter(|| uut.is_empty())
         });
         group.bench_with_input(
-            BenchmarkId::new("flexstr::SharedStr::from_static", len),
-            &len,
-            |b, _| {
-                let uut = flexstr::SharedStr::from_static(*fixture);
-                let uut = criterion::black_box(uut);
-                b.iter(|| uut.is_empty())
-            },
-        );
-        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_ref", len),
             &len,
             |b, _| {
                 let uut = flexstr::SharedStr::from_ref(*fixture);
-                let uut = criterion::black_box(uut);
-                b.iter(|| uut.is_empty())
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("KString::from_static", len),
-            &len,
-            |b, _| {
-                let uut = kstring::KString::from_static(*fixture);
                 let uut = criterion::black_box(uut);
                 b.iter(|| uut.is_empty())
             },
@@ -113,5 +81,46 @@ fn bench_access(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_access);
+fn bench_access_static(c: &mut Criterion) {
+    let mut group = c.benchmark_group("access_static");
+    for fixture in fixture::SAMPLES {
+        let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
+        group.bench_with_input(BenchmarkId::new("&'static str", len), &len, |b, _| {
+            let uut = *fixture;
+            let uut = criterion::black_box(uut);
+            b.iter(|| uut.is_empty())
+        });
+        group.bench_with_input(
+            BenchmarkId::new("StringCow::Borrowed", len),
+            &len,
+            |b, _| {
+                let uut = StringCow::Borrowed(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.is_empty())
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("flexstr::SharedStr::from_static", len),
+            &len,
+            |b, _| {
+                let uut = flexstr::SharedStr::from_static(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.is_empty())
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("KString::from_static", len),
+            &len,
+            |b, _| {
+                let uut = kstring::KString::from_static(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.is_empty())
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_access, bench_access_static);
 criterion_main!(benches);

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -15,11 +15,6 @@ fn bench_clone(c: &mut Criterion) {
     for fixture in fixture::SAMPLES {
         let len = fixture.len();
         group.throughput(Throughput::Bytes(len as u64));
-        group.bench_with_input(BenchmarkId::new("&'static str", len), &len, |b, _| {
-            let uut = *fixture;
-            let uut = criterion::black_box(uut);
-            b.iter(|| uut.clone())
-        });
         group.bench_with_input(BenchmarkId::new("String", len), &len, |b, _| {
             let uut = String::from(*fixture);
             let uut = criterion::black_box(uut);
@@ -35,15 +30,6 @@ fn bench_clone(c: &mut Criterion) {
             let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
-        group.bench_with_input(
-            BenchmarkId::new("StringCow::Borrowed", len),
-            &len,
-            |b, _| {
-                let uut = StringCow::Borrowed(*fixture);
-                let uut = criterion::black_box(uut);
-                b.iter(|| uut.clone())
-            },
-        );
         group.bench_with_input(BenchmarkId::new("StringCow::Owned", len), &len, |b, _| {
             let uut = StringCow::Owned(String::from(*fixture));
             let uut = criterion::black_box(uut);
@@ -55,28 +41,10 @@ fn bench_clone(c: &mut Criterion) {
             b.iter(|| uut.clone())
         });
         group.bench_with_input(
-            BenchmarkId::new("flexstr::SharedStr::from_static", len),
-            &len,
-            |b, _| {
-                let uut = flexstr::SharedStr::from_static(*fixture);
-                let uut = criterion::black_box(uut);
-                b.iter(|| uut.clone())
-            },
-        );
-        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_ref", len),
             &len,
             |b, _| {
                 let uut = flexstr::SharedStr::from_ref(*fixture);
-                let uut = criterion::black_box(uut);
-                b.iter(|| uut.clone())
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("KString::from_static", len),
-            &len,
-            |b, _| {
-                let uut = kstring::KString::from_static(*fixture);
                 let uut = criterion::black_box(uut);
                 b.iter(|| uut.clone())
             },
@@ -113,5 +81,46 @@ fn bench_clone(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_clone);
+fn bench_clone_static(c: &mut Criterion) {
+    let mut group = c.benchmark_group("clone_static");
+    for fixture in fixture::SAMPLES {
+        let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
+        group.bench_with_input(BenchmarkId::new("&'static str", len), &len, |b, _| {
+            let uut = *fixture;
+            let uut = criterion::black_box(uut);
+            b.iter(|| uut.clone())
+        });
+        group.bench_with_input(
+            BenchmarkId::new("StringCow::Borrowed", len),
+            &len,
+            |b, _| {
+                let uut = StringCow::Borrowed(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.clone())
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("flexstr::SharedStr::from_static", len),
+            &len,
+            |b, _| {
+                let uut = flexstr::SharedStr::from_static(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.clone())
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("KString::from_static", len),
+            &len,
+            |b, _| {
+                let uut = kstring::KString::from_static(*fixture);
+                let uut = criterion::black_box(uut);
+                b.iter(|| uut.clone())
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_clone, bench_clone_static);
 criterion_main!(benches);

--- a/benches/new.rs
+++ b/benches/new.rs
@@ -27,14 +27,6 @@ fn bench_new(c: &mut Criterion) {
             let fixture = criterion::black_box(*fixture);
             b.iter(|| std::sync::Arc::<str>::from(fixture))
         });
-        group.bench_with_input(
-            BenchmarkId::new("StringCow::Borrowed", len),
-            &len,
-            |b, _| {
-                let fixture = criterion::black_box(*fixture);
-                b.iter(|| StringCow::Borrowed(fixture))
-            },
-        );
         group.bench_with_input(BenchmarkId::new("StringCow::Owned", len), &len, |b, _| {
             let fixture = criterion::black_box(*fixture);
             b.iter(|| StringCow::Owned(String::from(fixture)))
@@ -44,27 +36,11 @@ fn bench_new(c: &mut Criterion) {
             b.iter(|| compact_str::CompactStr::new(fixture))
         });
         group.bench_with_input(
-            BenchmarkId::new("flexstr::SharedStr::from_static", len),
-            &len,
-            |b, _| {
-                let fixture = criterion::black_box(*fixture);
-                b.iter(|| flexstr::SharedStr::from_static(fixture))
-            },
-        );
-        group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_ref", len),
             &len,
             |b, _| {
                 let fixture = criterion::black_box(*fixture);
                 b.iter(|| flexstr::SharedStr::from_ref(fixture))
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("KString::from_static", len),
-            &len,
-            |b, _| {
-                let fixture = criterion::black_box(*fixture);
-                b.iter(|| kstring::KString::from_static(fixture))
             },
         );
         group.bench_with_input(BenchmarkId::new("KString::from_ref", len), &len, |b, _| {
@@ -95,5 +71,39 @@ fn bench_new(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_new);
+fn bench_new_static(c: &mut Criterion) {
+    let mut group = c.benchmark_group("new_static");
+    for fixture in fixture::SAMPLES {
+        let len = fixture.len();
+        group.throughput(Throughput::Bytes(len as u64));
+        group.bench_with_input(
+            BenchmarkId::new("StringCow::Borrowed", len),
+            &len,
+            |b, _| {
+                let fixture = criterion::black_box(*fixture);
+                b.iter(|| StringCow::Borrowed(fixture))
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("flexstr::SharedStr::from_static", len),
+            &len,
+            |b, _| {
+                let fixture = criterion::black_box(*fixture);
+                b.iter(|| flexstr::SharedStr::from_static(fixture))
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("KString::from_static", len),
+            &len,
+            |b, _| {
+                let fixture = criterion::black_box(*fixture);
+                b.iter(|| kstring::KString::from_static(fixture))
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_new, bench_new_static);
 criterion_main!(benches);


### PR DESCRIPTION
There is little reason to compare heap allocations to static and this
should make the charts more legible.