### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,9 +80,14 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e60dedcb8b23cedf6f23ee35ecf5c7889961e99f26f79ab196aaf4a8b48608"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
+dependencies = [
+ "castaway",
+ "itoa 1.0.1",
+ "ryu",
+]
 
 [[package]]
 name = "criterion"
@@ -408,6 +422,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-compact_str = "0.3.2"
+compact_str = "0.4"
 flexstr = "0.9.2"
 kstring = "2.0.0"
 smartstring = "1.0.1"

--- a/benches/access.rs
+++ b/benches/access.rs
@@ -35,8 +35,8 @@ fn bench_access(c: &mut Criterion) {
             let uut = criterion::black_box(uut);
             b.iter(|| uut.is_empty())
         });
-        group.bench_with_input(BenchmarkId::new("CompactStr::new", len), &len, |b, _| {
-            let uut = compact_str::CompactStr::new(fixture);
+        group.bench_with_input(BenchmarkId::new("CompactString::new", len), &len, |b, _| {
+            let uut = compact_str::CompactString::new(fixture);
             let uut = criterion::black_box(uut);
             b.iter(|| uut.is_empty())
         });

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -35,8 +35,8 @@ fn bench_clone(c: &mut Criterion) {
             let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });
-        group.bench_with_input(BenchmarkId::new("CompactStr::new", len), &len, |b, _| {
-            let uut = compact_str::CompactStr::new(fixture);
+        group.bench_with_input(BenchmarkId::new("CompactString::new", len), &len, |b, _| {
+            let uut = compact_str::CompactString::new(fixture);
             let uut = criterion::black_box(uut);
             b.iter(|| uut.clone())
         });

--- a/benches/new.rs
+++ b/benches/new.rs
@@ -31,9 +31,9 @@ fn bench_new(c: &mut Criterion) {
             let fixture = criterion::black_box(*fixture);
             b.iter(|| StringCow::Owned(String::from(fixture)))
         });
-        group.bench_with_input(BenchmarkId::new("CompactStr::new", len), &len, |b, _| {
+        group.bench_with_input(BenchmarkId::new("CompactString::new", len), &len, |b, _| {
             let fixture = criterion::black_box(*fixture);
-            b.iter(|| compact_str::CompactStr::new(fixture))
+            b.iter(|| compact_str::CompactString::new(fixture))
         });
         group.bench_with_input(
             BenchmarkId::new("flexstr::SharedStr::from_ref", len),


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning