### PR TITLE
Update compact_str to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
+checksum = "e464ece9cd4026f2fb9a2b97af84f7181109a84d877c8324385926206b0bd056"
 dependencies = [
  "castaway",
  "itoa 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-compact_str = "0.4"
+compact_str = "0.5"
 flexstr = "0.9.2"
 kstring = "2.0.0"
 smartstring = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Name                                                  | Heap  | Inline   | `&'st
 ------------------------------------------------------|-------|----------|----------------|---------|--------|-----
 `String`                                              | **Y** | \-       | N              | **Y**   | \-     | Universal
 `Cow<'static, str>`                                   | **Y** | \-       | **Y**          | N       | \-     |
-[`compact_str`](https://crates.io/crates/compact_str) | **Y** | 24 bytes | N              | **Y**   | **Y** (miri, proptest, fuzz)  |
+[`compact_str`](https://crates.io/crates/compact_str) | **Y** | 24 bytes | N              | **Y**   | **Y** (miri, proptest, fuzz)  | Space optimized for `Option<_>`
 [`flexstr`](https://crates.io/crates/flexstr)         | **Y** | 22 bytes | **Y**          | N       | **Y** (miri) | O(1) clone
 [`kstring`](https://crates.io/crates/kstring)         | **Y** | 15 bytes | **Y**          | N       | Optional (miri, proptest)  | Optional O(1) clone, optional 22 byte small string, Ref/Cow API for preserving `&'static str`
 [`smartstring`](https://crates.io/crates/smartstring) | **Y** | 23 bytes | N              | **Y**   | **Y** (miri, proptest, fuzz)  |


### PR DESCRIPTION
This PR updates `compact_str` to `v0.5` which includes several improvements, including storing an `Option<CompactString>` in the same amount of space as `CompactString`